### PR TITLE
Argparse and better dowanload folder structure

### DIFF
--- a/infoq_downloader.py
+++ b/infoq_downloader.py
@@ -1,15 +1,24 @@
 # TODO: To complete download of the file, use HTTP header 'Range': 'bytes=20-'
 from __future__ import division
-import os, sys, re, requests, lxml.html
+import os
+import sys
+import re
+import argparse
+import requests
+import lxml.html
 
-if len(sys.argv) != 2:
-    print '''Usage: {0} <url>'''.format(os.path.basename(__file__))
-    sys.exit(1)
 
-url = sys.argv[1]
+parser = argparse.ArgumentParser(description='Download InfoQ presentations.')
+parser.add_argument('url', metavar='URL', type=str,
+                    help='URL of the presentation to download')
+
+args = parser.parse_args()
+
+url = args.url
 
 # Tell infoq that I'm an iPad, so it gives me simpler HTML to parse & mp4 file to download
-user_agent = "Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B334b Safari/531.21.10')"
+user_agent = "Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 "\
+             "(KHTML, like Gecko) Version/4.0.4 Mobile/7B334b Safari/531.21.10')"
 print 'Downloading HTML file'
 content = requests.get(url, headers={'User-Agent': user_agent}).content
 html_doc = lxml.html.fromstring(content)
@@ -18,8 +27,9 @@ video_file = os.path.split(video_url)[1]
 html_doc.cssselect('video > source')[0].attrib['src'] = video_file
 
 # Clean the page
-for elt in html_doc.cssselect('#footer, #header, #topInfo, .share_this, .random_links, .vendor_vs_popular, .bottomContent, ' + 
-                              '#id_300x250_banner_top, .presentation_type, #conference, #imgPreload, #text_height_fix_box, ' +
+for elt in html_doc.cssselect('#footer, #header, #topInfo, .share_this, .random_links,' +
+                              ' .vendor_vs_popular, .bottomContent, #id_300x250_banner_top,' +
+                              ' .presentation_type, #conference, #imgPreload, #text_height_fix_box, ' +
                               '.download_presentation, .recorded, script[async]'):
     elt.getparent().remove(elt)
 html_doc.cssselect('#wrapper')[0].attrib['style'] = 'background: none'
@@ -69,4 +79,3 @@ with open(downloaded_file, 'ab') as f:
         print '\rDownloading video {0}%'.format(round(f.tell() / content_length, 2) * 100),
 
 os.rename(downloaded_file, video_file)
-    

--- a/infoq_downloader.py
+++ b/infoq_downloader.py
@@ -95,4 +95,4 @@ with open(downloaded_file, 'ab') as f:
         # The comma at the end of line is important, to stop the 'print' command from printing an additional new line
         print '\rDownloading video {0}%'.format(round(f.tell() / content_length, 2) * 100),
 
-os.rename(downloaded_file, video_file)
+os.rename(downloaded_file, '{}/{}/{}'.format(download_directory, title,video_file))

--- a/infoq_downloader.py
+++ b/infoq_downloader.py
@@ -8,21 +8,27 @@ import requests
 import lxml.html
 
 
+# Some settings
+download_directory = 'downloads'
+cleanup_elements = ['#footer', '#header', '#topInfo', '.share_this', '.random_links', '.vendor_vs_popular',
+                    '.bottomContent', '#id_300x250_banner_top', '.presentation_type', '#conference', '#imgPreload',
+                    '#text_height_fix_box', '.download_presentation', '.recorded', 'script[async]']
+
 # Set argparse to parse the paramaters
 parser = argparse.ArgumentParser(description='Download InfoQ presentations.')
 parser.add_argument('url', metavar='URL', type=str, help='URL of the presentation to download')
 
-# read the paramaters
+# Parse the arguments passed to the script
 args = parser.parse_args()
-
-# Set the url
 url = args.url
 
 # Tell infoq that I'm an iPad, so it gives me simpler HTML to parse & mp4 file to download
 user_agent = "Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 " \
              "(KHTML, like Gecko) Version/4.0.4 Mobile/7B334b Safari/531.21.10')"
 
+# Start downloading
 print 'Downloading HTML file'
+
 content = requests.get(url, headers={'User-Agent': user_agent}).content
 html_doc = lxml.html.fromstring(content)
 title = html_doc.find(".//title").text
@@ -31,11 +37,8 @@ video_file = os.path.split(video_url)[1]
 html_doc.cssselect('video > source')[0].attrib['src'] = video_file
 
 # Clean the page
-for elt in html_doc.cssselect('#footer, #header, #topInfo, .share_this, .random_links,' +
-                              ' .vendor_vs_popular, .bottomContent, #id_300x250_banner_top,' +
-                              ' .presentation_type, #conference, #imgPreload, #text_height_fix_box, ' +
-                              '.download_presentation, .recorded, script[async]'):
-    elt.getparent().remove(elt)
+for elt in html_doc.cssselect():
+    elt.getparent(', '.join(e for e in cleanup_elements)).remove(elt)
 html_doc.cssselect('#wrapper')[0].attrib['style'] = 'background: none'
 content = lxml.html.tostring(html_doc)
 
@@ -43,33 +46,34 @@ content = lxml.html.tostring(html_doc)
 slides_re = re.compile(r"'(/resource/presentations/[^']*?/en/slides/[^']*?)'")
 slides = slides_re.findall(content)
 
-# Create a directory for the downloaded presentation
-download_directory = 'downloads'
+# Create a directory for the downloaded presentation if it doesn't exist
+if not os.path.exists(download_directory):
+    os.makedirs(download_directory)
 
-# If the downloads folder does not exist, create it
-if not os.path.exists('{}'.format(download_directory)):
-    os.makedirs('{}'.format(download_directory))
-
+# presentation folder path
+presentation_directory = os.path.join(download_directory, title)
 # Create a folder with the name of the presentation
-if not os.path.exists('{}/{}'.format(download_directory, title)):
-    os.makedirs('{}/{}'.format(download_directory, title))
+if not os.path.exists(presentation_directory):
+    os.makedirs(presentation_directory)
 
 # Create a slides folder inside the presentation folder
-if not os.path.exists('{}/{}/slides'.format(download_directory, title)):
-    os.makedirs('{}/{}/slides'.format(download_directory, title))
+if not os.path.exists('{}/slides'.format(presentation_directory)):
+    os.makedirs('{}/slides'.format(presentation_directory))
 
+#Write content
 content = re.sub(r"/resource/presentations/[^']*?/en/", '', content)
-with open('{}/{}/index.html'.format(download_directory, title), 'w') as f:
+with open('{}/index.html'.format(presentation_directory), 'w') as f:
     f.write(content)
     f.flush()
 
 for i, slide in enumerate(slides):
     filename = os.path.split(slide)[1]
-    if os.path.exists('{}/{}'.format(download_directory, title) + '/slides/{0}'.format(filename)):
+    if os.path.exists(os.path.join(presentation_directory, 'slides', '{0}'.format(filename))):
         continue
     print '\rDownloading slide {0} of {1}'.format(i, len(slides)),
     url = 'http://www.infoq.com{0}'.format(slide)
-    open('{}/{}'.format(download_directory, title) + '/slides/{0}'.format(filename), 'wb').write(requests.get(url).content)
+    with open(os.path.join(presentation_directory, 'slides', '{0}'.format(filename), 'wb')) as f:
+        f.write(requests.get(url).content)
 
 print
 
@@ -95,4 +99,4 @@ with open(downloaded_file, 'ab') as f:
         # The comma at the end of line is important, to stop the 'print' command from printing an additional new line
         print '\rDownloading video {0}%'.format(round(f.tell() / content_length, 2) * 100),
 
-os.rename(downloaded_file, '{}/{}/{}'.format(download_directory, title,video_file))
+os.rename(downloaded_file, '{}/{}/{}'.format(download_directory, title, video_file))

--- a/infoq_downloader.py
+++ b/infoq_downloader.py
@@ -37,8 +37,8 @@ video_file = os.path.split(video_url)[1]
 html_doc.cssselect('video > source')[0].attrib['src'] = video_file
 
 # Clean the page
-for elt in html_doc.cssselect():
-    elt.getparent(', '.join(e for e in cleanup_elements)).remove(elt)
+for elt in html_doc.cssselect(', '.join(e for e in cleanup_elements)):
+    elt.getparent().remove(elt)
 html_doc.cssselect('#wrapper')[0].attrib['style'] = 'background: none'
 content = lxml.html.tostring(html_doc)
 
@@ -72,7 +72,7 @@ for i, slide in enumerate(slides):
         continue
     print '\rDownloading slide {0} of {1}'.format(i, len(slides)),
     url = 'http://www.infoq.com{0}'.format(slide)
-    with open(os.path.join(presentation_directory, 'slides', '{0}'.format(filename), 'wb')) as f:
+    with open(os.path.join(presentation_directory, 'slides', '{0}'.format(filename)), 'wb') as f:
         f.write(requests.get(url).content)
 
 print
@@ -82,7 +82,8 @@ if os.path.exists(video_file):
     sys.exit()
 
 # Download the video file. stream=True here is important to allow me to iterate over content
-downloaded_file = '{}/{}/{}.part'.format(download_directory, title, video_file)
+downloaded_file = os.path.join(presentation_directory, '{}.part'.format(video_file))
+
 if os.path.exists(downloaded_file):
     bytes_downloaded = os.stat(downloaded_file).st_size
 else:
@@ -99,4 +100,5 @@ with open(downloaded_file, 'ab') as f:
         # The comma at the end of line is important, to stop the 'print' command from printing an additional new line
         print '\rDownloading video {0}%'.format(round(f.tell() / content_length, 2) * 100),
 
-os.rename(downloaded_file, '{}/{}/{}'.format(download_directory, title, video_file))
+final_video_name = os.path.join(presentation_directory, video_file)
+os.rename(downloaded_file, final_video_name)

--- a/infoq_downloader.py
+++ b/infoq_downloader.py
@@ -8,20 +8,24 @@ import requests
 import lxml.html
 
 
+# Set argparse to parse the paramaters
 parser = argparse.ArgumentParser(description='Download InfoQ presentations.')
-parser.add_argument('url', metavar='URL', type=str,
-                    help='URL of the presentation to download')
+parser.add_argument('url', metavar='URL', type=str, help='URL of the presentation to download')
 
+# read the paramaters
 args = parser.parse_args()
 
+# Set the url
 url = args.url
 
 # Tell infoq that I'm an iPad, so it gives me simpler HTML to parse & mp4 file to download
-user_agent = "Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 "\
+user_agent = "Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 " \
              "(KHTML, like Gecko) Version/4.0.4 Mobile/7B334b Safari/531.21.10')"
+
 print 'Downloading HTML file'
 content = requests.get(url, headers={'User-Agent': user_agent}).content
 html_doc = lxml.html.fromstring(content)
+title = html_doc.find(".//title").text
 video_url = html_doc.cssselect('video > source')[0].attrib['src']
 video_file = os.path.split(video_url)[1]
 html_doc.cssselect('video > source')[0].attrib['src'] = video_file
@@ -39,20 +43,33 @@ content = lxml.html.tostring(html_doc)
 slides_re = re.compile(r"'(/resource/presentations/[^']*?/en/slides/[^']*?)'")
 slides = slides_re.findall(content)
 
+# Create a directory for the downloaded presentation
+download_directory = 'downloads'
+
+# If the downloads folder does not exist, create it
+if not os.path.exists('{}'.format(download_directory)):
+    os.makedirs('{}'.format(download_directory))
+
+# Create a folder with the name of the presentation
+if not os.path.exists('{}/{}'.format(download_directory, title)):
+    os.makedirs('{}/{}'.format(download_directory, title))
+
+# Create a slides folder inside the presentation folder
+if not os.path.exists('{}/{}/slides'.format(download_directory, title)):
+    os.makedirs('{}/{}/slides'.format(download_directory, title))
+
 content = re.sub(r"/resource/presentations/[^']*?/en/", '', content)
-with open('index.html', 'w') as f:
+with open('{}/{}/index.html'.format(download_directory, title), 'w') as f:
     f.write(content)
     f.flush()
 
 for i, slide in enumerate(slides):
-    if not os.path.exists('slides'):
-        os.mkdir('slides')
     filename = os.path.split(slide)[1]
-    if os.path.exists('slides/{0}'.format(filename)):
+    if os.path.exists('{}/{}'.format(download_directory, title) + '/slides/{0}'.format(filename)):
         continue
     print '\rDownloading slide {0} of {1}'.format(i, len(slides)),
     url = 'http://www.infoq.com{0}'.format(slide)
-    open('slides/{0}'.format(filename), 'wb').write(requests.get(url).content)
+    open('{}/{}'.format(download_directory, title) + '/slides/{0}'.format(filename), 'wb').write(requests.get(url).content)
 
 print
 
@@ -61,7 +78,7 @@ if os.path.exists(video_file):
     sys.exit()
 
 # Download the video file. stream=True here is important to allow me to iterate over content
-downloaded_file = video_file + '.part'
+downloaded_file = '{}/{}/{}.part'.format(download_directory, title, video_file)
 if os.path.exists(downloaded_file):
     bytes_downloaded = os.stat(downloaded_file).st_size
 else:


### PR DESCRIPTION
Hello Tayseer,

I replaced the sys.argv and the manual printing of usage with the "argrparse" module.

I also organized the downloads. Instead of downloading the presentation in the same folder as the code, I made the script create a "downloads" folder, then it creates another folder inside it with the title of the presentation and the presentation is downloaded there.

It works for the html and the slides, but I didn't get yet to test it with the video.
