### PR TITLE
normalise title to avoid issues with Unicode directory names

### DIFF
--- a/infoq_downloader.py
+++ b/infoq_downloader.py
@@ -8,6 +8,7 @@ import argparse
 import requests
 import cssselect
 import lxml.html
+import unicodedata
 
 
 # Some settings
@@ -54,7 +55,8 @@ if not os.path.exists(download_directory):
     os.makedirs(download_directory)
 
 # presentation folder path
-presentation_directory = os.path.join(download_directory, title)
+normalized_title = unicodedata.normalize('NFKD', title).encode('ASCII', 'ignore')
+presentation_directory = os.path.join(download_directory, normalized_title)
 # Create a folder with the name of the presentation
 if not os.path.exists(presentation_directory):
     os.makedirs(presentation_directory)


### PR DESCRIPTION
I encountered a problem downloading http://www.infoq.com/presentations/elasticsearch on Mac OS X, this fixes the problem by replacing the Unicode ellipsis character with three dots.
