### PR TITLE
Fix download of slides

### DIFF
--- a/infoq_downloader.py
+++ b/infoq_downloader.py
@@ -81,7 +81,7 @@ if not os.path.exists('{}/slides'.format(presentation_directory)):
     os.makedirs('{}/slides'.format(presentation_directory))
 
 # Write content
-content = re.sub(r"'[^']*?/resource/presentations/[^']*?/en/", '', content)
+content = re.sub(r"'[^']*?/resource/presentations/[^']*?/en/", '\'', content)
 with open('{}/index.html'.format(presentation_directory), 'w') as f:
     f.write(content)
     f.flush()

--- a/infoq_downloader.py
+++ b/infoq_downloader.py
@@ -59,7 +59,7 @@ html_doc.cssselect('#wrapper')[0].attrib['style'] = 'background: none'
 content = lxml.html.tostring(html_doc).decode('utf-8')
 
 # Make slides links point to local copies
-slides_re = re.compile(r"'(/resource/presentations/[^']*?/en/slides/[^']*?)'")
+slides_re = re.compile(r"'[^']*?(/resource/presentations/[^']*?/en/slides/[^']*?)'")
 slides = slides_re.findall(content)
 
 # Create a directory for the downloaded presentation if it doesn't exist
@@ -80,8 +80,8 @@ if not os.path.exists(presentation_directory):
 if not os.path.exists('{}/slides'.format(presentation_directory)):
     os.makedirs('{}/slides'.format(presentation_directory))
 
-#Write content
-content = re.sub(r"/resource/presentations/[^']*?/en/", '', content)
+# Write content
+content = re.sub(r"'[^']*?/resource/presentations/[^']*?/en/", '', content)
 with open('{}/index.html'.format(presentation_directory), 'w') as f:
     f.write(content)
     f.flush()


### PR DESCRIPTION
The download of slides stopped working a little while ago. It seems the reason was a change in the URL or InfoQ's CDN (?), which caused the regex that extracts the URLs to the slides not return anything, skipping the slide-download loop as well as confusing the URLs to the slides in the cleaned-up index.html that are supposed to point directly into the relative `slides/...` directory. This fix _should_ keep the downloads of slides working if there are any further changes in the structure of corresponding URLs in the future.

I did a quick test on Python2 and Python3 (Linux only), which seemed to work as intended. Windows not tested and only `infoq-downloader.py` touched.
